### PR TITLE
Correct typo in Survivorship Bias

### DIFF
--- a/6-survivorship-bias.yml
+++ b/6-survivorship-bias.yml
@@ -14,7 +14,7 @@ description: >
   be a useful exercise in combating survivorship bias.
 examples:
   - >
-    sWe often attribute the success of famous entrepreneurs solely to their
+    We often attribute the success of famous entrepreneurs solely to their
     behavior and overlook things like luck and timing. By ignoring the failed
     companies that followed similar approaches, we might be overly optimistic
     about the likelihood of our own entrepreneurial success.


### PR DESCRIPTION
Correct typo in examples in Survivorship Bias
sWe -> We